### PR TITLE
Add action for viewing an airline's conditions of carriage

### DIFF
--- a/src/airlines.tsx
+++ b/src/airlines.tsx
@@ -9,6 +9,7 @@ export interface Airline {
   iataCode: string;
   logoLockupUrl?: string;
   logoSymbolUrl?: string;
+  conditionsOfCarriageUrl?: string;
 }
 
 interface AirlineSearchState {
@@ -57,6 +58,9 @@ function AirlineListItem({ airline }: { airline: Airline }) {
         <ActionPanel>
           <ActionPanel.Section>
             <Action.CopyToClipboard title="Copy Name to Clipboard" content={airline.name} />
+            {airline.conditionsOfCarriageUrl && (
+              <Action.OpenInBrowser title="Open Conditions of Carriage" url={airline.conditionsOfCarriageUrl} />
+            )}
           </ActionPanel.Section>
         </ActionPanel>
       }


### PR DESCRIPTION
This takes the new `conditions_of_carriage_url` attribute returned for airlines in the Duffel API and allows you to navigate to an airline's conditions of carriage in your browser. This data is already being passed through by https://github.com/timrogers/iata-code-decoder-api.